### PR TITLE
using the public git clone url for the step reference

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,7 +25,7 @@ To use this step in your Bitrise workflow, prefix the step name with a Git URL o
 
 ```yml
 steps:
-  - git::git@github.com:netguru/bitrise-step-slack.git@master:
+  - git::https://github.com/netguru/bitrise-step-slack.git:
       title: slack
       inputs:
         - webhook_url: https://team.slack.com/...


### PR DESCRIPTION
the `git@github.com/..` one can only be used with proper SSH auth