### PR TITLE
return nil if no branch component contains jira proj key

### DIFF
--- a/lib/slack-step/environment.rb
+++ b/lib/slack-step/environment.rb
@@ -56,6 +56,7 @@ module SlackStep
           return "#{comps[0]}-#{comps[1]}".upcase
         end
       end
+      return nil
     end
 
     def slack_webhook_url


### PR DESCRIPTION
If none of the components inferred from branch name is matching format `branch/key-123`, then explicitly return `nil` instead of all components.

Check #11 for reference.
